### PR TITLE
Replaced the member variable password_ with the parameter password on

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -243,7 +243,7 @@ public:
      * 3.1.3.5 Password
      */
     void set_password(std::string password) {
-        password_ = std::move(password_);
+        password_ = std::move(password);
     }
 
     /**


### PR DESCRIPTION
RHS of the assignment.

This bug should be detected as an unused parameter warning, but client
is a class template and set_password is not used, so set_password()
isn't instantiated.

I added a test that is using set_password, but test.mosquito.org
rejected the connection that contains password. So I don't add test.