### PR TITLE
Fixed incomplete move semantics support.

### DIFF
--- a/example/no_tls.cpp
+++ b/example/no_tls.cpp
@@ -21,11 +21,11 @@ int main() {
     auto c = mqtt::make_client(ios, "test.mosquitto.org", 1883);
 
     // Setup client
-    c.set_client_id("cid1");
-    c.set_clean_session(true);
+    c->set_client_id("cid1");
+    c->set_clean_session(true);
 
     // Setup handlers
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&c, &pid_sub1, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code){
             std::cout << "Connack handler called" << std::endl;
@@ -33,42 +33,42 @@ int main() {
             std::cout << "Connack Return Code: "
                       << mqtt::connect_return_code_to_str(connack_return_code) << std::endl;
             if (connack_return_code == mqtt::connect_return_code::accepted) {
-                pid_sub1 = c.subscribe("mqtt_client_cpp/topic1", mqtt::qos::at_most_once);
-                pid_sub2 = c.subscribe("mqtt_client_cpp/topic2_1", mqtt::qos::at_least_once,
+                pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", mqtt::qos::at_most_once);
+                pid_sub2 = c->subscribe("mqtt_client_cpp/topic2_1", mqtt::qos::at_least_once,
                                        "mqtt_client_cpp/topic2_2", mqtt::qos::exactly_once);
             }
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         []
         (){
             std::cout << "closed." << std::endl;
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const& ec){
             std::cout << "error: " << ec.message() << std::endl;
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&c]
         (std::uint16_t packet_id){
             std::cout << "puback received. packet_id: " << packet_id << std::endl;
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&c]
         (std::uint16_t packet_id){
             std::cout << "pubrec received. packet_id: " << packet_id << std::endl;
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&c]
         (std::uint16_t packet_id){
             std::cout << "pubcomp received. packet_id: " << packet_id << std::endl;
             return true;
         });
     bool first = true;
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&c, &first, &pid_sub1, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results){
             std::cout << "suback received. packet_id: " << packet_id << std::endl;
@@ -81,15 +81,15 @@ int main() {
                 }
             }
             if (packet_id == pid_sub1) {
-                c.publish_at_most_once("mqtt_client_cpp/topic1", "test1");
+                c->publish_at_most_once("mqtt_client_cpp/topic1", "test1");
             }
             else if (packet_id == pid_sub2) {
-                c.publish_at_least_once("mqtt_client_cpp/topic2_1", "test2_1");
-                c.publish_exactly_once("mqtt_client_cpp/topic2_2", "test2_2");
+                c->publish_at_least_once("mqtt_client_cpp/topic2_1", "test2_1");
+                c->publish_exactly_once("mqtt_client_cpp/topic2_2", "test2_2");
             }
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&c, &count]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -103,12 +103,12 @@ int main() {
                 std::cout << "packet_id: " << *packet_id << std::endl;
             std::cout << "topic_name: " << topic_name << std::endl;
             std::cout << "contents: " << contents << std::endl;
-            if (++count == 3) c.disconnect();
+            if (++count == 3) c->disconnect();
             return true;
         });
 
     // Connect
-    c.connect();
+    c->connect();
 
     ios.run();
 }

--- a/example/tls.cpp
+++ b/example/tls.cpp
@@ -21,12 +21,12 @@ int main() {
     auto c = mqtt::make_tls_client(ios, "test.mosquitto.org", 8883);
 
     // Setup client
-    c.set_client_id("cid1");
-    c.set_clean_session(true);
-    c.set_ca_cert_file("mosquitto.org.crt");
+    c->set_client_id("cid1");
+    c->set_clean_session(true);
+    c->set_ca_cert_file("mosquitto.org.crt");
 
     // Setup handlers
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&c, &pid_sub1, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code){
             std::cout << "Connack handler called" << std::endl;
@@ -34,42 +34,42 @@ int main() {
             std::cout << "Connack Return Code: "
                       << mqtt::connect_return_code_to_str(connack_return_code) << std::endl;
             if (connack_return_code == mqtt::connect_return_code::accepted) {
-                pid_sub1 = c.subscribe("mqtt_client_cpp/topic1", mqtt::qos::at_most_once);
-                pid_sub2 = c.subscribe("mqtt_client_cpp/topic2_1", mqtt::qos::at_least_once,
+                pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", mqtt::qos::at_most_once);
+                pid_sub2 = c->subscribe("mqtt_client_cpp/topic2_1", mqtt::qos::at_least_once,
                                        "mqtt_client_cpp/topic2_2", mqtt::qos::exactly_once);
             }
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         []
         (){
             std::cout << "closed." << std::endl;
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const& ec){
             std::cout << "error: " << ec.message() << std::endl;
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&c]
         (std::uint16_t packet_id){
             std::cout << "puback received. packet_id: " << packet_id << std::endl;
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&c]
         (std::uint16_t packet_id){
             std::cout << "pubrec received. packet_id: " << packet_id << std::endl;
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&c]
         (std::uint16_t packet_id){
             std::cout << "pubcomp received. packet_id: " << packet_id << std::endl;
             return true;
         });
     bool first = true;
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&c, &first, &pid_sub1, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results){
             std::cout << "suback received. packet_id: " << packet_id << std::endl;
@@ -82,15 +82,15 @@ int main() {
                 }
             }
             if (packet_id == pid_sub1) {
-                c.publish_at_most_once("mqtt_client_cpp/topic1", "test1");
+                c->publish_at_most_once("mqtt_client_cpp/topic1", "test1");
             }
             else if (packet_id == pid_sub2) {
-                c.publish_at_least_once("mqtt_client_cpp/topic2_1", "test2_1");
-                c.publish_exactly_once("mqtt_client_cpp/topic2_2", "test2_2");
+                c->publish_at_least_once("mqtt_client_cpp/topic2_1", "test2_1");
+                c->publish_exactly_once("mqtt_client_cpp/topic2_2", "test2_2");
             }
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&c, &count]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -104,12 +104,12 @@ int main() {
                 std::cout << "packet_id: " << *packet_id << std::endl;
             std::cout << "topic_name: " << topic_name << std::endl;
             std::cout << "contents: " << contents << std::endl;
-            if (++count == 3) c.disconnect();
+            if (++count == 3) c->disconnect();
             return true;
         });
 
     // Connect
-    c.connect();
+    c->connect();
 
     ios.run();
 }

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -15,31 +15,31 @@ BOOST_AUTO_TEST_SUITE(test_connect)
 BOOST_AUTO_TEST_CASE( tls_connect ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_tls_client(ios, broker_url, broker_tls_port);
-    c.set_client_id(cid1());
-    c.set_ca_cert_file("mosquitto.org.crt");
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_ca_cert_file("mosquitto.org.crt");
+    c->set_clean_session(true);
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 1);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 2);
 }
@@ -47,31 +47,31 @@ BOOST_AUTO_TEST_CASE( tls_connect ) {
 BOOST_AUTO_TEST_CASE( tls_connect_no_strand ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_tls_client_no_strand(ios, broker_url, broker_tls_port);
-    c.set_client_id(cid1());
-    c.set_ca_cert_file("mosquitto.org.crt");
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_ca_cert_file("mosquitto.org.crt");
+    c->set_clean_session(true);
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 1);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 2);
 }
@@ -81,30 +81,30 @@ BOOST_AUTO_TEST_CASE( tls_connect_no_strand ) {
 BOOST_AUTO_TEST_CASE( notls_connect ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 1);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 2);
 }
@@ -112,30 +112,30 @@ BOOST_AUTO_TEST_CASE( notls_connect ) {
 BOOST_AUTO_TEST_CASE( notls_connect_no_strand ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 1);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 2);
 }
@@ -143,11 +143,11 @@ BOOST_AUTO_TEST_CASE( notls_connect_no_strand ) {
 BOOST_AUTO_TEST_CASE( notls_keep_alive ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
@@ -155,25 +155,25 @@ BOOST_AUTO_TEST_CASE( notls_keep_alive ) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 2);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_pingresp_handler(
+    c->set_pingresp_handler(
         [&order, &c]
         () {
             BOOST_TEST(order++ == 1);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_keep_alive_sec(3);
-    c.connect();
+    c->set_keep_alive_sec(3);
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 3);
 }
@@ -181,13 +181,13 @@ BOOST_AUTO_TEST_CASE( notls_keep_alive ) {
 BOOST_AUTO_TEST_CASE( notls_connect_again ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     bool first = true;
     int order = 0;
 
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&first, &order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             if (first) {
@@ -198,27 +198,27 @@ BOOST_AUTO_TEST_CASE( notls_connect_again ) {
             }
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&first, &order, &c]
         () {
             if (first) {
                 BOOST_TEST(order++ == 1);
                 first = false;
-                c.connect();
+                c->connect();
             }
             else {
                 BOOST_TEST(order++ == 3);
             }
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 4);
 }
@@ -226,29 +226,29 @@ BOOST_AUTO_TEST_CASE( notls_connect_again ) {
 BOOST_AUTO_TEST_CASE( notls_nocid ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 1);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 2);
 }
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE( notls_nocid_noclean ) {
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
@@ -266,17 +266,17 @@ BOOST_AUTO_TEST_CASE( notls_nocid_noclean ) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::identifier_rejected);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 1);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 2);
 }
@@ -284,11 +284,11 @@ BOOST_AUTO_TEST_CASE( notls_nocid_noclean ) {
 BOOST_AUTO_TEST_CASE( notls_noclean ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
+    c->set_client_id(cid1());
 
     int order = 0;
     int connect = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &connect, &c]
         (bool sp, std::uint8_t connack_return_code) {
             switch (connect) {
@@ -310,28 +310,28 @@ BOOST_AUTO_TEST_CASE( notls_noclean ) {
                 break;
             }
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order, &connect, &c]
         () {
             switch (connect) {
             case 0:
                 BOOST_TEST(order++ == 1);
-                c.connect();
+                c->connect();
                 ++connect;
                 break;
             case 1:
                 BOOST_TEST(order++ == 3);
-                c.set_clean_session(true);
-                c.connect();
+                c->set_clean_session(true);
+                c->connect();
                 ++connect;
                 break;
             case 2:
                 BOOST_TEST(order++ == 5);
-                c.set_clean_session(false);
-                c.connect();
+                c->set_clean_session(false);
+                c->connect();
                 ++connect;
                 break;
             case 3:
@@ -339,12 +339,12 @@ BOOST_AUTO_TEST_CASE( notls_noclean ) {
                 break;
             }
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 8);
 }

--- a/test/manual_publish.cpp
+++ b/test/manual_publish.cpp
@@ -14,44 +14,44 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     int order = 0;
     bool pub_seq_finished = false;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             BOOST_TEST(
-                c.subscribe(
+                c->subscribe(
                     0,
                     topic_base() + "/topic1",
                     mqtt::qos::at_most_once) == false);
             BOOST_TEST(
-                c.subscribe(
+                c->subscribe(
                     1,
                     topic_base() + "/topic1",
                     mqtt::qos::at_most_once) == true);
             BOOST_TEST(
-                c.subscribe(
+                c->subscribe(
                     1,
                     topic_base() + "/topic1",
                     mqtt::qos::at_most_once) == false);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 5);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pub_seq_finished]
         (std::uint16_t packet_id) {
             BOOST_TEST(packet_id == 1);
@@ -63,12 +63,12 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 {
                     std::uint16_t packet_id = 0;
                     BOOST_TEST(
-                        c.unsubscribe(packet_id, topic_base() + "/topic1") == false);
+                        c->unsubscribe(packet_id, topic_base() + "/topic1") == false);
                 }
                 BOOST_TEST(
-                    c.unsubscribe(1, topic_base() + "/topic1") == true);
+                    c->unsubscribe(1, topic_base() + "/topic1") == true);
                 BOOST_TEST(
-                    c.unsubscribe(1, topic_base() + "/topic1") == false);
+                    c->unsubscribe(1, topic_base() + "/topic1") == false);
                 break;
             default:
                 BOOST_CHECK(false);
@@ -76,52 +76,52 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             }
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == 1);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            BOOST_TEST(c.publish(
+            BOOST_TEST(c->publish(
                            0,
                            topic_base() + "/topic1",
                            "topic1_contents",
                            mqtt::qos::at_least_once) == false);
-            BOOST_TEST(c.publish(
+            BOOST_TEST(c->publish(
                            1,
                            topic_base() + "/topic1",
                            "topic1_contents",
                            mqtt::qos::at_least_once) == true);
-            BOOST_TEST(c.publish(
+            BOOST_TEST(c->publish(
                            1,
                            topic_base() + "/topic1",
                            "topic1_contents",
                            mqtt::qos::at_least_once) == false);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 4);
             if (pub_seq_finished) BOOST_TEST(packet_id == 1);
             else BOOST_TEST(packet_id == 1);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             case 2:
                 break;
             case 3:
-                c.unsubscribe(topic_base() + "/topic1");
+                c->unsubscribe(topic_base() + "/topic1");
                 break;
             default:
                 BOOST_CHECK(false);
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             }
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 6);
 }

--- a/test/multi_sub.cpp
+++ b/test/multi_sub.cpp
@@ -14,53 +14,53 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(
+            pid_sub = c->subscribe(
                 topic_base() + "/topic1", mqtt::qos::at_most_once,
                 topic_base() + "/topic2", mqtt::qos::at_most_once);
 
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 5);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
@@ -68,18 +68,18 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
             BOOST_TEST(results.size() == 2U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
             BOOST_TEST(*results[1] == mqtt::qos::at_most_once);
-            c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+            c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 4);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -93,12 +93,12 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
             case 2:
                 BOOST_TEST(topic == topic_base() + "/topic1");
                 BOOST_TEST(contents == "topic1_contents");
-                c.publish_at_most_once(topic_base() + "/topic2", "topic2_contents");
+                c->publish_at_most_once(topic_base() + "/topic2", "topic2_contents");
                 break;
             case 3:
                 BOOST_TEST(topic == topic_base() + "/topic2");
                 BOOST_TEST(contents == "topic2_contents");
-                pid_unsub = c.unsubscribe(
+                pid_unsub = c->unsubscribe(
                     topic_base() + "/topic1",
                     topic_base() + "/topic2");
                 break;
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
             }
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 6);
 }
@@ -122,47 +122,47 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
     std::uint16_t pid_unsub1;
 
     auto c1 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c1.set_clean_session(true);
+    c1->set_clean_session(true);
 
     int order1 = 0;
-    c1.set_connack_handler(
+    c1->set_connack_handler(
         [&order1, &c1, &pid_sub1]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order1++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub1 = c1.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub1 = c1->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c1.set_close_handler(
+    c1->set_close_handler(
         [&order1]
         () {
             BOOST_TEST(order1++ == 4);
         });
-    c1.set_error_handler(
+    c1->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c1.set_puback_handler(
+    c1->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c1.set_pubrec_handler(
+    c1->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c1.set_pubcomp_handler(
+    c1->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c1.set_suback_handler(
+    c1->set_suback_handler(
         [&order1, &c1, &sub_count, &pid_sub1]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order1++ == 1);
@@ -170,18 +170,18 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
             if (++sub_count == 2)
-                c1.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+                c1->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c1.set_unsuback_handler(
+    c1->set_unsuback_handler(
         [&order1, &c1, &pid_unsub1]
         (std::uint16_t packet_id) {
             BOOST_TEST(order1++ == 3);
             BOOST_TEST(packet_id == pid_unsub1);
-            c1.disconnect();
+            c1->disconnect();
             return true;
         });
-    c1.set_publish_handler(
+    c1->set_publish_handler(
         [&order1, &c1, &pid_unsub1]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -194,55 +194,55 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
             BOOST_TEST(order1++ == 2);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub1 = c1.unsubscribe(topic_base() + "/topic1");
+            pid_unsub1 = c1->unsubscribe(topic_base() + "/topic1");
             return true;
         });
 
     auto c2 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c2.set_clean_session(true);
+    c2->set_clean_session(true);
 
     std::uint16_t pid_sub2;
     std::uint16_t pid_unsub2;
 
     int order2 = 0;
-    c2.set_connack_handler(
+    c2->set_connack_handler(
         [&order2, &c2, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order2++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub2 = c2.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub2 = c2->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c2.set_close_handler(
+    c2->set_close_handler(
         [&order2]
         () {
             BOOST_TEST(order2++ == 4);
         });
-    c2.set_error_handler(
+    c2->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c2.set_puback_handler(
+    c2->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c2.set_pubrec_handler(
+    c2->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c2.set_pubcomp_handler(
+    c2->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c2.set_suback_handler(
+    c2->set_suback_handler(
         [&order2, &c2, &sub_count, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
@@ -250,18 +250,18 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
             if (++sub_count == 2)
-                c2.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+                c2->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c2.set_unsuback_handler(
+    c2->set_unsuback_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint16_t packet_id) {
             BOOST_TEST(order2++ == 3);
             BOOST_TEST(packet_id == pid_unsub2);
-            c2.disconnect();
+            c2->disconnect();
             return true;
         });
-    c2.set_publish_handler(
+    c2->set_publish_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -274,12 +274,12 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
             BOOST_TEST(order2++ == 2);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub2 = c2.unsubscribe(topic_base() + "/topic1");
+            pid_unsub2 = c2->unsubscribe(topic_base() + "/topic1");
             return true;
         });
 
-    c1.connect();
-    c2.connect();
+    c1->connect();
+    c2->connect();
 
     ios.run();
     BOOST_TEST(order1++ == 5);
@@ -298,9 +298,9 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
     auto c1 = mqtt::make_client(ios, broker_url, broker_notls_port);
     auto c2 = mqtt::make_client(ios, broker_url, broker_notls_port);
     auto c3 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c1.set_clean_session(true);
-    c2.set_clean_session(true);
-    c3.set_clean_session(true);
+    c1->set_clean_session(true);
+    c2->set_clean_session(true);
+    c3->set_clean_session(true);
     int order1 = 0;
     int order2 = 0;
     int order3 = 0;
@@ -310,26 +310,26 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
     std::uint16_t pid_sub1;
     std::uint16_t pid_unsub1;
 
-    c1.set_connack_handler(
+    c1->set_connack_handler(
         [&order1, &c1, &pid_sub1]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order1++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub1 = c1.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub1 = c1->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c1.set_close_handler(
+    c1->set_close_handler(
         [&order1]
         () {
             BOOST_TEST(order1++ == 4);
         });
-    c1.set_error_handler(
+    c1->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c1.set_suback_handler(
+    c1->set_suback_handler(
         [&order1, &c1, &sub_count, &c1ready, &c2ready, &c3ready, &c3, &pid_sub1, &pid_pub3]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order1++ == 1);
@@ -339,19 +339,19 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
 
             c1ready = true;
             if (c1ready && c2ready && c3ready) {
-                pid_pub3 = c3.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+                pid_pub3 = c3->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             }
             return true;
         });
-    c1.set_unsuback_handler(
+    c1->set_unsuback_handler(
         [&order1, &c1, &pid_unsub1]
         (std::uint16_t packet_id) {
             BOOST_TEST(order1++ == 3);
             BOOST_TEST(packet_id == pid_unsub1);
-            c1.disconnect();
+            c1->disconnect();
             return true;
         });
-    c1.set_publish_handler(
+    c1->set_publish_handler(
         [&order1, &c1, &pid_unsub1]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -364,33 +364,33 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
             BOOST_TEST(order1++ == 2);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub1 = c1.unsubscribe(topic_base() + "/topic1");
+            pid_unsub1 = c1->unsubscribe(topic_base() + "/topic1");
             return true;
         });
 
     std::uint16_t pid_sub2;
     std::uint16_t pid_unsub2;
 
-    c2.set_connack_handler(
+    c2->set_connack_handler(
         [&order2, &c2, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order2++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub2 = c2.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub2 = c2->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c2.set_close_handler(
+    c2->set_close_handler(
         [&order2]
         () {
             BOOST_TEST(order2++ == 4);
         });
-    c2.set_error_handler(
+    c2->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c2.set_suback_handler(
+    c2->set_suback_handler(
         [&order2, &c2, &sub_count, &c1ready, &c2ready, &c3ready, &c3, &pid_sub2, &pid_pub3]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
@@ -400,19 +400,19 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
 
             c2ready = true;
             if (c1ready && c2ready && c3ready) {
-                pid_pub3 = c3.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+                pid_pub3 = c3->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             }
             return true;
         });
-    c2.set_unsuback_handler(
+    c2->set_unsuback_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint16_t packet_id) {
             BOOST_TEST(order2++ == 3);
             BOOST_TEST(packet_id == pid_unsub2);
-            c2.disconnect();
+            c2->disconnect();
             return true;
         });
-    c2.set_publish_handler(
+    c2->set_publish_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -425,11 +425,11 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
             BOOST_TEST(order2++ == 2);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub2 = c2.unsubscribe(topic_base() + "/topic1");
+            pid_unsub2 = c2->unsubscribe(topic_base() + "/topic1");
             return true;
         });
 
-    c3.set_connack_handler(
+    c3->set_connack_handler(
         [&order3, &c3, &c1ready, &c2ready, &c3ready, &pid_pub3]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order3++ == 0);
@@ -437,44 +437,44 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             c3ready = true;
             if (c1ready && c2ready && c3ready) {
-                pid_pub3 = c3.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+                pid_pub3 = c3->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             }
             return true;
         });
-    c3.set_close_handler(
+    c3->set_close_handler(
         [&order3]
         () {
             BOOST_TEST(order3++ == 2);
         });
-    c3.set_error_handler(
+    c3->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c3.set_puback_handler(
+    c3->set_puback_handler(
         [&order3, &c3, &pid_pub3]
         (std::uint16_t packet_id) {
             BOOST_TEST(order3++ == 1);
             BOOST_TEST(packet_id == pid_pub3);
-            c3.disconnect();
+            c3->disconnect();
             return true;
         });
-    c3.set_pubrec_handler(
+    c3->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c3.set_pubcomp_handler(
+    c3->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
 
-    c1.connect();
-    c2.connect();
-    c3.connect();
+    c1->connect();
+    c2->connect();
+    c3->connect();
 
     ios.run();
     BOOST_TEST(order1++ == 5);

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -14,73 +14,73 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+            c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -93,10 +93,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
     bool pub_seq_finished = false;
 
     std::uint16_t pid_pub;
@@ -113,30 +113,30 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(
+            pid_sub = c->subscribe(
                 std::vector<std::pair<std::string, std::uint8_t>> {
                     std::make_pair(topic_base() + "/topic1", mqtt::qos::at_most_once)
                 }
             );
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 5);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -144,47 +144,47 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 4) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(
+                pid_unsub = c->unsubscribe(
                     std::vector<std::string> {topic_base() + "/topic1"});
             }
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_pub, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            pid_pub = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 4);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -198,10 +198,10 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             BOOST_TEST(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 4) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 4) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 6);
 }
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -218,32 +218,32 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 6);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
@@ -259,34 +259,34 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 5) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == 1);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 5);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -300,10 +300,10 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 5) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 5) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 7);
 }
@@ -312,73 +312,73 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_least_once);
-            c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+            c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -391,10 +391,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -411,26 +411,26 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 6);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3 || order == 4);
@@ -438,51 +438,51 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 5) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
     boost::optional<std::uint16_t> recv_packet_id;
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         [&order, &c, &pid_unsub, &recv_packet_id]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
             ++order;
             BOOST_TEST(*recv_packet_id == packet_id);
-            if (order == 5) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 5) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_least_once);
-            pid_pub = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 5);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &recv_packet_id]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             BOOST_TEST(contents == "topic1_contents");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 7);
 }
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -516,32 +516,32 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 7);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3 || order == 4);
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4 || order == 5);
@@ -557,39 +557,39 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 6) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
     boost::optional<std::uint16_t> recv_packet_id;
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         [&order, &c, &pid_unsub, &recv_packet_id]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4 || order == 5);
             ++order;
             BOOST_TEST(*recv_packet_id == packet_id);
-            if (order == 6) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 6) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_least_once);
-            pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 6);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &recv_packet_id]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -606,7 +606,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             BOOST_TEST(contents == "topic1_contents");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 8);
 }
@@ -615,73 +615,73 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::exactly_once);
-            c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+            c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -694,10 +694,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -706,7 +706,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -714,26 +714,26 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 6);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3 || order == 4);
@@ -741,51 +741,51 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 5) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
     boost::optional<std::uint16_t> recv_packet_id;
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         [&order, &c, &pid_unsub, &recv_packet_id]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
             ++order;
             BOOST_TEST(*recv_packet_id == packet_id);
-            if (order == 5) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 5) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::exactly_once);
-            pid_pub = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 5);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &recv_packet_id]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -802,7 +802,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             BOOST_TEST(contents == "topic1_contents");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 7);
 }
@@ -811,7 +811,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -819,32 +819,32 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 7);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -852,7 +852,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4 || order == 5);
@@ -860,39 +860,39 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 6) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
     boost::optional<std::uint16_t> recv_packet_id;
-    c.set_pub_res_sent_handler(
+    c->set_pub_res_sent_handler(
         [&order, &c, &pid_unsub, &recv_packet_id]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4 || order == 5);
             ++order;
             BOOST_TEST(*recv_packet_id == packet_id);
-            if (order == 6) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 6) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::exactly_once);
-            pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 6);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &recv_packet_id]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -909,7 +909,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             BOOST_TEST(contents == "topic1_contents");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 8);
 }
@@ -918,68 +918,68 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c.publish(topic_base() + "/topic1", "topic1_contents", mqtt::qos::at_most_once);
+            c->publish(topic_base() + "/topic1", "topic1_contents", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -992,10 +992,10 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }

--- a/test/pubsub_no_strand.cpp
+++ b/test/pubsub_no_strand.cpp
@@ -14,70 +14,70 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
             return true;
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+            c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -90,10 +90,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
     bool pub_seq_finished = false;
 
     std::uint16_t pid_pub;
@@ -110,26 +110,26 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 5);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -137,41 +137,41 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 4) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_pub, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            pid_pub = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 4);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -185,10 +185,10 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             BOOST_TEST(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 4) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 4) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 6);
 }
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -205,32 +205,32 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 6);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
@@ -246,29 +246,29 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 5) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == 1);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 5);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -282,10 +282,10 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 5) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 5) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 7);
 }
@@ -294,68 +294,68 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_least_once);
-            c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+            c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -368,10 +368,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -388,26 +388,26 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 5);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -415,42 +415,42 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 4) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_least_once);
-            pid_pub = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -464,10 +464,10 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             BOOST_TEST(*packet_id != 0);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 4) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 4) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 6);
 }
@@ -476,7 +476,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -484,32 +484,32 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 6);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -517,7 +517,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
@@ -525,30 +525,30 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 5) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_least_once);
-            pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 4 || order == 5);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -562,10 +562,10 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             BOOST_TEST(*packet_id != 0);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 5) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 5) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 7);
 }
@@ -574,68 +574,68 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::exactly_once);
-            c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
+            c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -648,10 +648,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -660,7 +660,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -668,26 +668,26 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 5);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -695,42 +695,42 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 4) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::exactly_once);
-            pid_pub = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -744,10 +744,10 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             BOOST_TEST(*packet_id != 0);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 4) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 4) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 6);
 }
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
     std::uint16_t pid_sub;
@@ -764,32 +764,32 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 
     bool pub_seq_finished = false;
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 6);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 2 || order == 3);
@@ -797,7 +797,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
@@ -805,30 +805,30 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             BOOST_TEST(packet_id == pid_pub);
             if (order == 5) {
                 pub_seq_finished = true;
-                pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+                pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             }
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &pid_pub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::exactly_once);
-            pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+            pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pub_seq_finished, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 4 || order == 5);
             ++order;
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -842,10 +842,10 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             BOOST_TEST(*packet_id != 0);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            if (order == 5) pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            if (order == 5) pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 7);
 }
@@ -854,68 +854,68 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client_no_strand(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c.publish(topic_base() + "/topic1", "topic1_contents", mqtt::qos::at_most_once);
+            c->publish(topic_base() + "/topic1", "topic1_contents", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -928,10 +928,10 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }

--- a/test/remaining_length.cpp
+++ b/test/remaining_length.cpp
@@ -19,68 +19,68 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
 
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &test_contents]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c.publish_at_most_once(topic_base() + "/topic1", test_contents);
+            c->publish_at_most_once(topic_base() + "/topic1", test_contents);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub, &test_contents]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -93,10 +93,10 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == test_contents);
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -110,68 +110,68 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
 
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &test_contents]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c.publish_at_most_once(topic_base() + "/topic1", test_contents);
+            c->publish_at_most_once(topic_base() + "/topic1", test_contents);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub, &test_contents]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -184,10 +184,10 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == test_contents);
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -203,68 +203,68 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_2097152 ) {
 
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub, &test_contents]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c.publish_at_most_once(topic_base() + "/topic1", test_contents);
+            c->publish_at_most_once(topic_base() + "/topic1", test_contents);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub, &test_contents]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -277,10 +277,10 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_2097152 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == test_contents);
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -12,25 +12,25 @@ BOOST_AUTO_TEST_SUITE(test_resend)
 BOOST_AUTO_TEST_CASE( publish_qos1 ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_pub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             switch (order++) {
             case 0: // clean session
                 BOOST_TEST(sp == false);
-                c.disconnect();
+                c->disconnect();
                 break;
             case 2:
                 BOOST_TEST(sp == false);
-                pid_pub = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
-                c.force_disconnect();
+                pid_pub = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents");
+                c->force_disconnect();
                 break;
             case 4:
                 BOOST_TEST(sp == true);
@@ -41,13 +41,13 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
             }
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order, &c]
         () {
             switch (order++) {
             case 1:
-                c.set_clean_session(false);
-                c.connect();
+                c->set_clean_session(false);
+                c->connect();
                 break;
             case 6:
                 break;
@@ -56,21 +56,21 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 break;
             }
         });
-    c.set_error_handler(
+    c->set_error_handler(
         [&order, &c]
         (boost::system::error_code const&) {
             BOOST_TEST(order++ == 3);
-            c.connect();
+            c->connect();
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 5);
             BOOST_TEST(packet_id == pid_pub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 7);
 }
@@ -78,25 +78,25 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
 BOOST_AUTO_TEST_CASE( publish_qos2 ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_pub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             switch (order++) {
             case 0: // clean session
                 BOOST_TEST(sp == false);
-                c.disconnect();
+                c->disconnect();
                 break;
             case 2:
                 BOOST_TEST(sp == false);
-                pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
-                c.force_disconnect();
+                pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+                c->force_disconnect();
                 break;
             case 4:
                 BOOST_TEST(sp == true);
@@ -107,13 +107,13 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
             }
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order, &c]
         () {
             switch (order++) {
             case 1:
-                c.set_clean_session(false);
-                c.connect();
+                c->set_clean_session(false);
+                c->connect();
                 break;
             case 7:
                 break;
@@ -122,28 +122,28 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 break;
             }
         });
-    c.set_error_handler(
+    c->set_error_handler(
         [&order, &c]
         (boost::system::error_code const&) {
             BOOST_TEST(order++ == 3);
-            c.connect();
+            c->connect();
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 5);
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 6);
             BOOST_TEST(packet_id == pid_pub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 8);
 }
@@ -151,24 +151,24 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
 BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_pub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             switch (order++) {
             case 0: // clean session
                 BOOST_TEST(sp == false);
-                c.disconnect();
+                c->disconnect();
                 break;
             case 2:
                 BOOST_TEST(sp == false);
-                pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+                pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
                 break;
             case 5:
                 BOOST_TEST(sp == true);
@@ -179,13 +179,13 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             }
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order, &c]
         () {
             switch (order++) {
             case 1:
-                c.set_clean_session(false);
-                c.connect();
+                c->set_clean_session(false);
+                c->connect();
                 break;
             case 7:
                 break;
@@ -194,19 +194,19 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
                 break;
             }
         });
-    c.set_error_handler(
+    c->set_error_handler(
         [&order, &c]
         (boost::system::error_code const&) {
             BOOST_TEST(order++ == 4);
-            c.connect();
+            c->connect();
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id) {
             switch (order++) {
             case 3:
                 BOOST_TEST(packet_id == pid_pub);
-                c.force_disconnect();
+                c->force_disconnect();
                 break;
             default:
                 BOOST_CHECK(false);
@@ -214,15 +214,15 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             }
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 6);
             BOOST_TEST(packet_id == 1);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 8);
 }
@@ -230,25 +230,25 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
 BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, & pid_pub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             switch (order++) {
             case 0: // clean session
                 BOOST_TEST(sp == false);
-                c.disconnect();
+                c->disconnect();
                 break;
             case 2:
                 BOOST_TEST(sp == false);
-                pid_pub = c.publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
-                c.force_disconnect();
+                pid_pub = c->publish_exactly_once(topic_base() + "/topic1", "topic1_contents");
+                c->force_disconnect();
                 break;
             case 4:
                 BOOST_TEST(sp == true);
@@ -262,13 +262,13 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
             }
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order, &c]
         () {
             switch (order++) {
             case 1:
-                c.set_clean_session(false);
-                c.connect();
+                c->set_clean_session(false);
+                c->connect();
                 break;
             case 9:
                 break;
@@ -277,28 +277,28 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
                 break;
             }
         });
-    c.set_error_handler(
+    c->set_error_handler(
         [&order, &c]
         (boost::system::error_code const&) {
             switch (order++) {
             case 3:
-                c.connect();
+                c->connect();
                 break;
             case 6:
-                c.connect();
+                c->connect();
                 break;
             default:
                 BOOST_CHECK(false);
                 break;
             }
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id) {
             switch (order++) {
             case 5:
                 BOOST_TEST(packet_id == pid_pub);
-                c.force_disconnect();
+                c->force_disconnect();
                 break;
             default:
                 BOOST_CHECK(false);
@@ -306,15 +306,15 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
             }
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         [&order, &c, &pid_pub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 8);
             BOOST_TEST(packet_id == pid_pub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 10);
 }
@@ -322,27 +322,27 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
 BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_client_id(cid1());
-    c.set_clean_session(true);
+    c->set_client_id(cid1());
+    c->set_clean_session(true);
 
     std::uint16_t pid_pub1;
     std::uint16_t pid_pub2;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_pub1, &pid_pub2]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             switch (order++) {
             case 0: // clean session
                 BOOST_TEST(sp == false);
-                c.disconnect();
+                c->disconnect();
                 break;
             case 2:
                 BOOST_TEST(sp == false);
-                pid_pub1 = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents1");
-                pid_pub2 = c.publish_at_least_once(topic_base() + "/topic1", "topic1_contents2");
-                c.force_disconnect();
+                pid_pub1 = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents1");
+                pid_pub2 = c->publish_at_least_once(topic_base() + "/topic1", "topic1_contents2");
+                c->force_disconnect();
                 break;
             case 4:
                 BOOST_TEST(sp == true);
@@ -353,13 +353,13 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             }
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order, &c]
         () {
             switch (order++) {
             case 1:
-                c.set_clean_session(false);
-                c.connect();
+                c->set_clean_session(false);
+                c->connect();
                 break;
             case 7:
                 break;
@@ -368,13 +368,13 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 break;
             }
         });
-    c.set_error_handler(
+    c->set_error_handler(
         [&order, &c]
         (boost::system::error_code const&) {
             BOOST_TEST(order++ == 3);
-            c.connect();
+            c->connect();
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         [&order, &c, &pid_pub1, &pid_pub2]
         (std::uint16_t packet_id) {
             switch (order++) {
@@ -385,10 +385,10 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 BOOST_TEST(packet_id == pid_pub2);
                 break;
             }
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 8);
 }

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -13,53 +13,53 @@ BOOST_AUTO_TEST_SUITE(test_retain)
 BOOST_AUTO_TEST_CASE( simple ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
 
-            c.publish_at_most_once(topic_base() + "/topic1", "retained_contents", true);
+            c->publish_at_most_once(topic_base() + "/topic1", "retained_contents", true);
 
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
@@ -68,15 +68,15 @@ BOOST_AUTO_TEST_CASE( simple ) {
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -89,10 +89,10 @@ BOOST_AUTO_TEST_CASE( simple ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "retained_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -100,55 +100,55 @@ BOOST_AUTO_TEST_CASE( simple ) {
 BOOST_AUTO_TEST_CASE( overwrite ) {
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
 
-            c.publish_at_most_once(topic_base() + "/topic1", "retained_contents1", true);
-            c.publish_at_most_once(topic_base() + "/topic1", "retained_contents2", true);
-            c.publish_at_most_once(topic_base() + "/topic1", "retained_contents3", false);
+            c->publish_at_most_once(topic_base() + "/topic1", "retained_contents1", true);
+            c->publish_at_most_once(topic_base() + "/topic1", "retained_contents2", true);
+            c->publish_at_most_once(topic_base() + "/topic1", "retained_contents3", false);
 
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 4);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order++ == 1);
@@ -157,15 +157,15 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 3);
             BOOST_TEST(packet_id == pid_unsub);
-            c.disconnect();
+            c->disconnect();
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -178,10 +178,10 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "retained_contents2");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 5);
 }
@@ -190,50 +190,50 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
     fixture_clear_retain();
     boost::asio::io_service ios;
     auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c.set_clean_session(true);
+    c->set_clean_session(true);
 
     std::uint16_t pid_sub;
     std::uint16_t pid_unsub;
 
     int order = 0;
-    c.set_connack_handler(
+    c->set_connack_handler(
         [&order, &c, &pid_sub]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c.set_close_handler(
+    c->set_close_handler(
         [&order]
         () {
             BOOST_TEST(order++ == 7);
         });
-    c.set_error_handler(
+    c->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c.set_puback_handler(
+    c->set_puback_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubrec_handler(
+    c->set_pubrec_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_pubcomp_handler(
+    c->set_pubcomp_handler(
         []
         (std::uint16_t) {
             BOOST_CHECK(false);
             return true;
         });
-    c.set_suback_handler(
+    c->set_suback_handler(
         [&order, &c, &pid_sub]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(packet_id == pid_sub);
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
             switch (order++) {
             case 1:
-                c.publish_at_most_once(topic_base() + "/topic1", "topic1_contents", true);
+                c->publish_at_most_once(topic_base() + "/topic1", "topic1_contents", true);
                 break;
             case 4:
                 break;
@@ -251,16 +251,16 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
             }
             return true;
         });
-    c.set_unsuback_handler(
+    c->set_unsuback_handler(
         [&order, &c, &pid_sub, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(packet_id == pid_unsub);
             switch (order++) {
             case 3:
-                pid_sub = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+                pid_sub = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
                 break;
             case 6:
-                c.disconnect();
+                c->disconnect();
                 break;
             default:
                 BOOST_CHECK(false);
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
             }
             return true;
         });
-    c.set_publish_handler(
+    c->set_publish_handler(
         [&order, &c, &pid_unsub]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "topic1_contents");
-            pid_unsub = c.unsubscribe(topic_base() + "/topic1");
+            pid_unsub = c->unsubscribe(topic_base() + "/topic1");
             switch (order++) {
             case 2:
                 BOOST_TEST(mqtt::publish::is_retain(header) == false);
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
             }
             return true;
         });
-    c.connect();
+    c->connect();
     ios.run();
     BOOST_TEST(order++ == 8);
 }

--- a/test/test_settings.hpp
+++ b/test/test_settings.hpp
@@ -57,38 +57,38 @@ struct fixture_clear_retain {
         bool sub2 = false;
         std::size_t count = 0;
         auto c = mqtt::make_client(ios, broker_url, broker_notls_port);
-        c.set_clean_session(true);
-        c.set_connack_handler(
+        c->set_clean_session(true);
+        c->set_connack_handler(
             [&]
             (bool, std::uint8_t connack_return_code) {
                 BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
                 // Clear retaind contents
-                pid_sub1 = c.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
-                pid_sub2 = c.subscribe(topic_base() + "/topic2", mqtt::qos::at_least_once);
+                pid_sub1 = c->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+                pid_sub2 = c->subscribe(topic_base() + "/topic2", mqtt::qos::at_least_once);
                 return true;
             });
-        c.set_suback_handler(
+        c->set_suback_handler(
             [&]
             (std::uint16_t pid, std::vector<boost::optional<std::uint8_t>>) {
                 if (pid == pid_sub1) sub1 = true;
                 if (pid == pid_sub2) sub2 = true;
                 if (sub1 && sub2) {
-                    pid_clear1 = c.publish_at_least_once(topic_base() + "/topic1", "", true);
-                    pid_clear2 = c.publish_at_least_once(topic_base() + "/topic2", "", true);
+                    pid_clear1 = c->publish_at_least_once(topic_base() + "/topic1", "", true);
+                    pid_clear2 = c->publish_at_least_once(topic_base() + "/topic2", "", true);
                 }
                 return true;
             });
-        c.set_puback_handler(
+        c->set_puback_handler(
             [&]
             (std::uint16_t pid) {
                 if (pid == pid_clear1) clear1 = true;
                 if (pid == pid_clear2) clear2 = true;
                 if (count == 2 && clear1 && clear2) {
-                    c.disconnect();
+                    c->disconnect();
                 }
                 return true;
             });
-        c.set_publish_handler(
+        c->set_publish_handler(
             [&]
             (std::uint8_t,
              boost::optional<std::uint16_t>,
@@ -96,11 +96,11 @@ struct fixture_clear_retain {
              std::string) {
                 ++count;
                 if (count == 2 && clear1 && clear2) {
-                    c.disconnect();
+                    c->disconnect();
                 }
                 return true;
             });
-        c.connect();
+        c->connect();
         ios.run();
     }
 };

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -15,17 +15,17 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
     boost::asio::io_service ios;
 
     auto c1 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c1.set_client_id(cid1());
-    c1.set_clean_session(true);
-    c1.set_will(
+    c1->set_client_id(cid1());
+    c1->set_clean_session(true);
+    c1->set_will(
         mqtt::will(topic_base() + "/topic1", "will_contents"));
 
     auto c2 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c2.set_client_id(cid2());
-    c2.set_clean_session(true);
+    c2->set_client_id(cid2());
+    c2->set_clean_session(true);
 
     int order1 = 0;
-    c1.set_connack_handler(
+    c1->set_connack_handler(
         [&order1, &c1]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order1++ == 0);
@@ -33,12 +33,12 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             return true;
         });
-    c1.set_close_handler(
+    c1->set_close_handler(
         []
         () {
             BOOST_CHECK(false);
         });
-    c1.set_error_handler(
+    c1->set_error_handler(
         [&order1]
         (boost::system::error_code const&) {
             BOOST_TEST(order1++ == 1);
@@ -48,44 +48,44 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
     std::uint16_t pid_unsub2;
 
     int order2 = 0;
-    c2.set_connack_handler(
+    c2->set_connack_handler(
         [&order2, &c2, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order2++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub2 = c2.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub2 = c2->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c2.set_close_handler(
+    c2->set_close_handler(
         [&order2]
         () {
             BOOST_TEST(order2++ == 4);
         });
-    c2.set_error_handler(
+    c2->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c2.set_suback_handler(
+    c2->set_suback_handler(
         [&order2, &c2, &c1, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
-            c1.force_disconnect();
+            c1->force_disconnect();
             return true;
         });
-    c2.set_unsuback_handler(
+    c2->set_unsuback_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint16_t packet_id) {
             BOOST_TEST(order2++ == 3);
             BOOST_TEST(packet_id == pid_unsub2);
-            c2.disconnect();
+            c2->disconnect();
             return true;
         });
-    c2.set_publish_handler(
+    c2->set_publish_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -98,12 +98,12 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "will_contents");
-            pid_unsub2 = c2.unsubscribe(topic_base() + "/topic1");
+            pid_unsub2 = c2->unsubscribe(topic_base() + "/topic1");
             return true;
         });
 
-    c1.connect();
-    c2.connect();
+    c1->connect();
+    c2->connect();
 
     ios.run();
     BOOST_TEST(order1++ == 2);
@@ -115,17 +115,17 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
     boost::asio::io_service ios;
 
     auto c1 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c1.set_client_id(cid1());
-    c1.set_clean_session(true);
-    c1.set_will(
+    c1->set_client_id(cid1());
+    c1->set_clean_session(true);
+    c1->set_will(
         mqtt::will(topic_base() + "/topic1", "will_contents", mqtt::qos::at_least_once));
 
     auto c2 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c2.set_client_id(cid2());
-    c2.set_clean_session(true);
+    c2->set_client_id(cid2());
+    c2->set_clean_session(true);
 
     int order1 = 0;
-    c1.set_connack_handler(
+    c1->set_connack_handler(
         [&order1, &c1]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order1++ == 0);
@@ -133,12 +133,12 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             return true;
         });
-    c1.set_close_handler(
+    c1->set_close_handler(
         []
         () {
             BOOST_CHECK(false);
         });
-    c1.set_error_handler(
+    c1->set_error_handler(
         [&order1]
         (boost::system::error_code const&) {
             BOOST_TEST(order1++ == 1);
@@ -148,44 +148,44 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
     std::uint16_t pid_unsub2;
 
     int order2 = 0;
-    c2.set_connack_handler(
+    c2->set_connack_handler(
         [&order2, &c2, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order2++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub2 = c2.subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
+            pid_sub2 = c2->subscribe(topic_base() + "/topic1", mqtt::qos::at_least_once);
             return true;
         });
-    c2.set_close_handler(
+    c2->set_close_handler(
         [&order2]
         () {
             BOOST_TEST(order2++ == 4);
         });
-    c2.set_error_handler(
+    c2->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c2.set_suback_handler(
+    c2->set_suback_handler(
         [&order2, &c2, &c1, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::at_least_once);
-            c1.force_disconnect();
+            c1->force_disconnect();
             return true;
         });
-    c2.set_unsuback_handler(
+    c2->set_unsuback_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint16_t packet_id) {
             BOOST_TEST(order2++ == 3);
             BOOST_TEST(packet_id == pid_unsub2);
-            c2.disconnect();
+            c2->disconnect();
             return true;
         });
-    c2.set_publish_handler(
+    c2->set_publish_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -198,12 +198,12 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
             BOOST_CHECK(*packet_id != 0);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "will_contents");
-            pid_unsub2 = c2.unsubscribe(topic_base() + "/topic1");
+            pid_unsub2 = c2->unsubscribe(topic_base() + "/topic1");
             return true;
         });
 
-    c1.connect();
-    c2.connect();
+    c1->connect();
+    c2->connect();
 
     ios.run();
     BOOST_TEST(order1++ == 2);
@@ -215,17 +215,17 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
     boost::asio::io_service ios;
 
     auto c1 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c1.set_client_id(cid1());
-    c1.set_clean_session(true);
-    c1.set_will(
+    c1->set_client_id(cid1());
+    c1->set_clean_session(true);
+    c1->set_will(
         mqtt::will(topic_base() + "/topic1", "will_contents", mqtt::qos::exactly_once));
 
     auto c2 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c2.set_client_id(cid2());
-    c2.set_clean_session(true);
+    c2->set_client_id(cid2());
+    c2->set_clean_session(true);
 
     int order1 = 0;
-    c1.set_connack_handler(
+    c1->set_connack_handler(
         [&order1, &c1]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order1++ == 0);
@@ -233,12 +233,12 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             return true;
         });
-    c1.set_close_handler(
+    c1->set_close_handler(
         []
         () {
             BOOST_CHECK(false);
         });
-    c1.set_error_handler(
+    c1->set_error_handler(
         [&order1]
         (boost::system::error_code const&) {
             BOOST_TEST(order1++ == 1);
@@ -248,44 +248,44 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
     std::uint16_t pid_unsub2;
 
     int order2 = 0;
-    c2.set_connack_handler(
+    c2->set_connack_handler(
         [&order2, &c2, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order2++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub2 = c2.subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
+            pid_sub2 = c2->subscribe(topic_base() + "/topic1", mqtt::qos::exactly_once);
             return true;
         });
-    c2.set_close_handler(
+    c2->set_close_handler(
         [&order2]
         () {
             BOOST_TEST(order2++ == 4);
         });
-    c2.set_error_handler(
+    c2->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c2.set_suback_handler(
+    c2->set_suback_handler(
         [&order2, &c2, &c1, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
             BOOST_TEST(*results[0] == mqtt::qos::exactly_once);
-            c1.force_disconnect();
+            c1->force_disconnect();
             return true;
         });
-    c2.set_unsuback_handler(
+    c2->set_unsuback_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint16_t packet_id) {
             BOOST_TEST(order2++ == 3);
             BOOST_TEST(packet_id == pid_unsub2);
-            c2.disconnect();
+            c2->disconnect();
             return true;
         });
-    c2.set_publish_handler(
+    c2->set_publish_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -298,12 +298,12 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
             BOOST_CHECK(*packet_id != 0);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "will_contents");
-            pid_unsub2 = c2.unsubscribe(topic_base() + "/topic1");
+            pid_unsub2 = c2->unsubscribe(topic_base() + "/topic1");
             return true;
         });
 
-    c1.connect();
-    c2.connect();
+    c1->connect();
+    c2->connect();
 
     ios.run();
     BOOST_TEST(order1++ == 2);
@@ -315,17 +315,17 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
     boost::asio::io_service ios;
 
     auto c1 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c1.set_client_id(cid1());
-    c1.set_clean_session(true);
-    c1.set_will(
+    c1->set_client_id(cid1());
+    c1->set_clean_session(true);
+    c1->set_will(
         mqtt::will(topic_base() + "/topic1", "will_contents", true));
 
     auto c2 = mqtt::make_client(ios, broker_url, broker_notls_port);
-    c2.set_client_id(cid2());
-    c2.set_clean_session(true);
+    c2->set_client_id(cid2());
+    c2->set_clean_session(true);
 
     int order1 = 0;
-    c1.set_connack_handler(
+    c1->set_connack_handler(
         [&order1, &c1]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order1++ == 0);
@@ -333,12 +333,12 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
             return true;
         });
-    c1.set_close_handler(
+    c1->set_close_handler(
         []
         () {
             BOOST_CHECK(false);
         });
-    c1.set_error_handler(
+    c1->set_error_handler(
         [&order1]
         (boost::system::error_code const&) {
             BOOST_TEST(order1++ == 1);
@@ -348,26 +348,26 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
     std::uint16_t pid_unsub2;
 
     int order2 = 0;
-    c2.set_connack_handler(
+    c2->set_connack_handler(
         [&order2, &c2, &pid_sub2]
         (bool sp, std::uint8_t connack_return_code) {
             BOOST_TEST(order2++ == 0);
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-            pid_sub2 = c2.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+            pid_sub2 = c2->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
             return true;
         });
-    c2.set_close_handler(
+    c2->set_close_handler(
         [&order2]
         () {
             BOOST_TEST(order2++ == 7);
         });
-    c2.set_error_handler(
+    c2->set_error_handler(
         []
         (boost::system::error_code const&) {
             BOOST_CHECK(false);
         });
-    c2.set_suback_handler(
+    c2->set_suback_handler(
         [&order2, &c2, &c1, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(packet_id == pid_sub2);
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
             BOOST_TEST(*results[0] == mqtt::qos::at_most_once);
             switch (order2++) {
             case 1:
-                c1.force_disconnect();
+                c1->force_disconnect();
                 break;
             case 4:
                 break;
@@ -384,16 +384,16 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
             }
             return true;
         });
-    c2.set_unsuback_handler(
+    c2->set_unsuback_handler(
         [&order2, &c2, &pid_unsub2, &pid_sub2]
         (std::uint16_t packet_id) {
             BOOST_TEST(packet_id == pid_unsub2);
             switch (order2++) {
             case 3:
-                pid_sub2 = c2.subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
+                pid_sub2 = c2->subscribe(topic_base() + "/topic1", mqtt::qos::at_most_once);
                 break;
             case 6:
-                c2.disconnect();
+                c2->disconnect();
                 break;
             default:
                 BOOST_CHECK(false);
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
             }
             return true;
         });
-    c2.set_publish_handler(
+    c2->set_publish_handler(
         [&order2, &c2, &pid_unsub2]
         (std::uint8_t header,
          boost::optional<std::uint16_t> packet_id,
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == topic_base() + "/topic1");
             BOOST_TEST(contents == "will_contents");
-            pid_unsub2 = c2.unsubscribe(topic_base() + "/topic1");
+            pid_unsub2 = c2->unsubscribe(topic_base() + "/topic1");
             switch (order2++) {
             case 2:
                 BOOST_TEST(mqtt::publish::is_retain(header) == false);
@@ -427,8 +427,8 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
             return true;
         });
 
-    c1.connect();
-    c2.connect();
+    c1->connect();
+    c2->connect();
 
     ios.run();
     BOOST_TEST(order1++ == 2);


### PR DESCRIPTION
endpoint and client is now not movable. Use shared_ptr.
make_* functions return shared_ptr.

Fixed #51.