### PR TITLE
workaround ssl short read error

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -1608,7 +1608,8 @@ public:
         connected_ = false;
         shutdown(*socket_);
         if (ec == as::error::eof ||
-            ec == as::error::connection_reset) {
+            ec == as::error::connection_reset ||
+            ec.value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)) {
             handle_close();
             return true;
         }

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -1614,12 +1614,13 @@ public:
             handle_close();
             return true;
         }
-        #endif // defined(MQTT_NO_TLS)
+        #else
         if (ec == as::error::eof ||
             ec == as::error::connection_reset) {
             handle_close();
             return true;
         }
+        #endif // defined(MQTT_NO_TLS)
         handle_error(ec);
         return true;
     }

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -1607,9 +1607,16 @@ public:
         if (!ec) return false;
         connected_ = false;
         shutdown(*socket_);
+        #if !defined(MQTT_NO_TLS)
         if (ec == as::error::eof ||
             ec == as::error::connection_reset ||
             ec.value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)) {
+            handle_close();
+            return true;
+        }
+        #endif // defined(MQTT_NO_TLS)
+        if (ec == as::error::eof ||
+            ec == as::error::connection_reset) {
             handle_close();
             return true;
         }

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -1607,20 +1607,21 @@ public:
         if (!ec) return false;
         connected_ = false;
         shutdown(*socket_);
-        #if !defined(MQTT_NO_TLS)
         if (ec == as::error::eof ||
-            ec == as::error::connection_reset ||
-            ec.value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)) {
+            ec == as::error::connection_reset
+            #if !defined(MQTT_NO_TLS)
+                ||
+                ec.value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)
+            #endif // defined(MQTT_NO_TLS)
+            ) {
             handle_close();
             return true;
         }
-        #else
         if (ec == as::error::eof ||
             ec == as::error::connection_reset) {
             handle_close();
             return true;
         }
-        #endif // defined(MQTT_NO_TLS)
         handle_error(ec);
         return true;
     }


### PR DESCRIPTION
When we close SSL connection on boost::asio libraries, we get "ssl sort read error".
In normally, we get errors and call handle_error(), but we have to close connection in this case.
So I add the code which ignores "ssl short read error" when closes SSL connection.

This problem was reported to Boost Trac.
[Boost C++ Libraries] #12528: boost::asio::ssl_stream "short read error" when a connection is closed
https://svn.boost.org/trac/boost/ticket/12528