### PR TITLE
Avoid needlessly using C++14 syntax.

### DIFF
--- a/include/mqtt/null_strand.hpp
+++ b/include/mqtt/null_strand.hpp
@@ -17,7 +17,8 @@ struct null_strand {
     null_strand(as::io_service& ios) : ios_(ios) {}
     template <typename Func>
     void post(Func&& f) {
-        ios_.post([f = std::forward<Func>(f)]{ f(); });
+        auto ff = wrap(f);
+        ios_.post([ff]{ ff(); });
     }
     template <typename Func>
     void dispatch(Func&& f) {


### PR DESCRIPTION
The README says C++14 is only needed for binary literals; so keep the code behave like that ;-)