### PR TITLE
Removed TLS manual shutdown() call.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -2221,20 +2221,17 @@ private:
     template <typename T>
     void shutdown_from_client(as::ssl::stream<T>& socket) {
         boost::system::error_code ec;
-        socket.shutdown(ec);
         socket.lowest_layer().close(ec);
     }
     template <typename T>
     void shutdown_from_server(as::ssl::stream<T>& socket) {
         boost::system::error_code ec;
-        socket.shutdown(ec);
         socket.lowest_layer().close(ec);
     }
 #if defined(MQTT_USE_WS)
     template <typename T>
     void shutdown_from_client(ws_endpoint<as::ssl::stream<T>>& socket) {
         boost::system::error_code ec;
-        socket.next_layer().shutdown(ec);
         socket.lowest_layer().close(ec);
     }
     template <typename T>


### PR DESCRIPTION
When endpoint calls socket.shutdown() , it can be blocked forever (very rare case). It happened my project using mqtt_client_cpp.

I considered replacing shutdown with async_shutdown and set a deadline_timer. But it is a little complicated. 

Simpler solution is just close TCP layer socket. The counter part of the connection could observe TLS_SHORT_READ but it is not a big problem. As far as I used Boost.Asio, SSL_SHORT_READ is unavoidable ( not caused by this modification).

So mqtt_client_cpp treats the SSL_SHORT_READ as a normal close.
