### PR TITLE
Expose set_default_verify_paths for SSL context

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -145,6 +145,10 @@ public:
     make_tls_client_no_strand_ws(as::io_service& ios, std::string host, std::string port, std::string path);
 #endif // defined(MQTT_USE_WS)
 
+    void set_default_verify_paths() {
+        ctx_.set_default_verify_paths();
+    }
+
     void set_ca_cert_file(std::string file) {
         ctx_.load_verify_file(std::move(file));
     }


### PR DESCRIPTION
boost::asio's ssl context provides a convenience method `set_default_verify_paths` (see http://www.boost.org/doc/libs/1_64_0/doc/html/boost_asio/reference/ssl__context/set_default_verify_paths.html). Exposing the method from mqtt::client makes it easy for users to select the "right" location to load certificate authorities from.